### PR TITLE
Update NodeJS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ outputs:
   result:
     description: Merged configuration as JSON or plain text.
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: layers

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Load configuration and merge it by redefinition levels",
   "main": "dist/index.js",
   "scripts": {
-    "dist": "$(npm bin)/ncc build index.js -m --license licenses.txt",
-    "lint": "$(npm bin)/eslint .",
-    "test": "$(npm bin)/jest --runInBand"
+    "dist": "NODE_OPTIONS=--openssl-legacy-provider ncc build index.js -m --license licenses.txt",
+    "lint": "eslint .",
+    "test": "jest --runInBand"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use node16 to avoid warning

```
The following actions uses node12 which is deprecated and will be forced to run on node16: blablacar/action-config-levels@dc8ddbca36875e29f870e53bcc1160b7000ff5b2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```